### PR TITLE
1.2.0 Command Patch & Bug Fixes.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,8 +8,8 @@
 #
 #============================================================================================================================|
 #
-# Plugin Version: 1.1.1
-# Spigot Link: TBA
+# Plugin Version: 1.2.0
+# Spigot Link: https://www.spigotmc.org/resources/morphredeem-mcmmo-credits-1-14.67435/
 # Discord Link: https://discord.gg/6bnU9xn
 # Author's Discord: Morphie#6969
 # 
@@ -18,28 +18,22 @@
 #
 #============================================================================================================================|
 
-# Storage method, can be MySQL or YML
-StorageMethod: "YML"
-
-# Requires 'StorageMethod' to be MySQL
-MySQL:
-  Username: "root"
-  Password: "password"
-  Host: "localhost"
-  Port: 3306
-  SSL: false
-  Database: "minecraft"
-  TablePrefix: "mr_"
-  
 Settings:
+  # The color of glass in the main /morphreedem menu.
   BackgroundGlassColor: 11
   DisabledSkills:
     Enabled: false
+    # Item to replace disabled Skills with.
     ReplaceGUIItem:
       Enabled: false
       ItemName: STRUCTURE_VOID
+    # Skills that players won't be able to apply credits to.
     SkillsToDisable:
     - Acrobatics
+  # Enable or disable the plugin credits item in the /morphredeem menu.
+  PluginCredits:
+    Enabled: true
+  # Change the Item types in the main /morphredeem menu.
   GUI:
     Acrobatics:
       ItemName: LEATHER_BOOTS
@@ -73,3 +67,20 @@ Settings:
       ItemName: EMERALD
     PluginCredits:
       ItemName: PAPER
+
+#============================================================================================================================|
+
+# Storage method, can be MySQL or YML
+StorageMethod: "YML"
+
+# Requires 'StorageMethod' to be MySQL
+MySQL:
+  Username: "root"
+  Password: "password"
+  Host: "localhost"
+  Port: 3306
+  SSL: false
+  Database: "minecraft"
+  TablePrefix: "mr_"
+  
+#============================================================================================================================|

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,12 +1,12 @@
 name: MorphRedeem
-version: 1.1.1
+version: 1.2.0
 main: net.naturva.morphie.mr.MorphRedeem
 author: Morphie
 api-version: 1.13
 depend: [mcMMO]
 softdepend: [PlaceholderAPI]
 commands:
-   mr:
+   morphredeem:
     description: Main command for the MorphRedeem plugin!
     usage: /<command>
-    aliases: [redeem]
+    aliases: [mr, redeem]

--- a/src/net/naturva/morphie/mr/Commands.java
+++ b/src/net/naturva/morphie/mr/Commands.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -11,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import com.gmail.nossr50.api.ExperienceAPI;
+import com.gmail.nossr50.api.exceptions.McMMOPlayerNotFoundException;
 
 import net.md_5.bungee.api.ChatColor;
 import net.naturva.morphie.mr.files.PlayerFileMethods;
@@ -27,12 +29,17 @@ public class Commands implements CommandExecutor {
 	}
 	
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-		if (cmd.getName().equalsIgnoreCase("mr") || cmd.getName().equalsIgnoreCase("redeem")) {
+		if (cmd.getName().equalsIgnoreCase("morphredeem") || cmd.getName().equalsIgnoreCase("redeem") || cmd.getName().equalsIgnoreCase("mr")) {
 			if (args.length == 0) {
 				Player player = (Player)sender;
 				if (sender.hasPermission("morphredeem.redeem")) {
-					new RedeemMenu(this.plugin).openGUIRedeem(player);
-					return true;
+					try {
+						new RedeemMenu(this.plugin).openGUIRedeem(player);
+						return true;
+					} catch (McMMOPlayerNotFoundException e1) {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("McMMOPlayerNotLoadedMessage")));
+						return true;
+					}
 				} else {
 					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
 					return true;
@@ -46,10 +53,14 @@ public class Commands implements CommandExecutor {
 					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.MR")));
 					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.MRSkill")));
 					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Credits")));
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.CreditsOthers")));
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Send")));
 					sender.sendMessage("");
 					if (sender.hasPermission("morphredeem.admin") || sender.hasPermission("morphredeem.reload")) {
 						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Add")));
 						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Remove")));
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Set")));
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Reset")));
 						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Commands.Reload")));
 					}
 					sender.sendMessage("");
@@ -63,12 +74,38 @@ public class Commands implements CommandExecutor {
 			} else if (args[0].equalsIgnoreCase("Credits")) {
 				Player player = (Player)sender;
 				UUID uuid = player.getUniqueId();
-				if (sender.hasPermission("morphredeem.credits")) {
-					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("PlayerCreditsMessage").replace("%CREDITS%", new dataManager(plugin).getData(uuid, "Credits"))));
-					return true;
-				} else {
-					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
-					return true;
+				if (args.length == 1) {
+					if (sender.hasPermission("morphredeem.credits")) {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("PlayerCreditsMessage").replace("%CREDITS%", new dataManager(plugin).getData(uuid, "Credits"))));
+						return true;
+					} else {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+						return true;
+					}
+				} else if (args.length == 2) {
+					if (sender.hasPermission("morphredeem.credits.others")) {
+						Player target = null;
+						OfflinePlayer offTarget = null;
+						if (Bukkit.getPlayer(args[1]) != null) {
+							target = Bukkit.getPlayer(args[1]);
+							String targetCredits = new dataManager(plugin).getData(target.getUniqueId(), "Credits");
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("OtherPlayerCreditMessage").replace("%PLAYER%", target.getName()).replace("%CREDITS%", targetCredits)));
+							return true;
+						} else {
+							offTarget = (OfflinePlayer)Bukkit.getServer().getOfflinePlayer(args[1]);
+							if (getFileExists(offTarget.getUniqueId())) {
+								String targetCredits = new dataManager(plugin).getData(offTarget.getUniqueId(), "Credits");
+								sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("OtherPlayerCreditMessage").replace("%PLAYER%", offTarget.getName()).replace("%CREDITS%", targetCredits)));
+								return true;	
+							} else {
+								sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+								return true;
+							}
+						}
+					} else {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+						return true;
+					}
 				}
 			} else if (args[0].equalsIgnoreCase("Add")) {
 				if (sender.hasPermission("morphredeem.admin") || sender.hasPermission("morphredeem.addcredits")) {
@@ -76,35 +113,40 @@ public class Commands implements CommandExecutor {
 						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Add")));
 						return true;
 					}
-					int amount = Integer.parseInt(args[2]);
-			        if (Bukkit.getServer().getPlayer(args[1]) != null) {
-				        Player target = Bukkit.getServer().getPlayer(args[1]); 
-				        UUID targetUUID = target.getUniqueId();
-			        	try {
-			        		Integer.parseInt(args[2]);
-			            }
-			            catch (NumberFormatException e) {
-			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Add")));
-			            	return true;
-			            }
-			            if (amount <= 0) {
-			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Add")));
-			            	return true;
-			            }
-			            new dataManager(plugin).updateData(targetUUID, +amount, "Credits", "add");
-			            if (sender == target) {
-			            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddMessage").replace("%CREDITS%", "" + amount)));
-			            	return true;
-			            } else {
+		        	try {
+		        		Integer.parseInt(args[2]);
+		            }
+		            catch (NumberFormatException e) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Add")));
+		            	return true;
+		            }
+		        	int amount = Integer.parseInt(args[2]);
+		            if (amount <= 0) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Add")));
+		            	return true;
+		            }
+					Player target = null;
+					OfflinePlayer offTarget = null;
+					UUID targetUUID = null;
+					if (Bukkit.getPlayer(args[1]) != null) {
+			        	target = Bukkit.getPlayer(args[1]);
+			        	targetUUID = target.getUniqueId();
+					} else if (checkIfUUID(args[1]) == true) {
+			        	targetUUID = UUID.fromString(args[1]);
+			        	target = Bukkit.getPlayer(targetUUID);
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, +amount, "Credits", "add");
 			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddSuccessMessage")));
-			            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddMessage").replace("%CREDITS%", "" + amount)));
-			            	return true;
-			            }
-			        } else {
-						Player player = (Player)sender;
-						UUID uuid2 = Bukkit.getServer().getOfflinePlayer(args[1]).getUniqueId();
-						if (getFileExists(uuid2)) {
-							new dataManager(plugin).updateData(uuid2, +amount, "Credits", "add");
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        } else if (checkIfUUID(args[1]) == false && Bukkit.getPlayer(args[1]) == null) {
+						offTarget = (OfflinePlayer)Bukkit.getServer().getOfflinePlayer(args[1]);
+						targetUUID = offTarget.getUniqueId();
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, +amount, "Credits", "add");
 			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddSuccessMessage")));
 							return true;
 						} else {
@@ -112,6 +154,18 @@ public class Commands implements CommandExecutor {
 							return true;
 						}
 			        }
+					new dataManager(plugin).updateData(targetUUID, +amount, "Credits", "add");
+		            if (sender == target) {
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddMessage").replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            } else {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddSuccessMessage")));
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditAddMessage").replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            }
+		        } else {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+					return true;
 				}
 			} else if (args[0].equalsIgnoreCase("remove")) {
 				if (sender.hasPermission("morphredeem.admin") || sender.hasPermission("morphredeem.removecredits")) {
@@ -119,40 +173,56 @@ public class Commands implements CommandExecutor {
 						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
 						return true;
 					}
-					int amount = Integer.parseInt(args[2]);
-			        if (Bukkit.getServer().getPlayer(args[1]) != null) {
-				        Player target = Bukkit.getServer().getPlayer(args[1]); 
-				        UUID targetUUID = target.getUniqueId();
-				        int credits = Integer.parseInt(new dataManager(plugin).getData(targetUUID, "Credits"));
-			        	try {
-			        		Integer.parseInt(args[2]);
-			            }
-			            catch (NumberFormatException e) {
-			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
-			            	return true;
-			            }
-			            if (amount <= 0) {
-			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
-			            	return true;
-			            }
+			        int amount = Integer.parseInt(args[2]);
+		        	try {
+		        		Integer.parseInt(args[2]);
+		            }
+		            catch (NumberFormatException e) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
+		            	return true;
+		            }
+		            if (amount <= 0) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
+		            	return true;
+		            }
+					Player target = null;
+					OfflinePlayer offTarget = null;
+					UUID targetUUID = null;
+					int credits = 0;
+					if (Bukkit.getPlayer(args[1]) != null) {
+			        	target = Bukkit.getPlayer(args[1]);
+			        	targetUUID = target.getUniqueId();
+			        	credits = Integer.parseInt(new dataManager(plugin).getData(targetUUID, "Credits"));
 			            if (amount > credits) {
 			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
 			            	return true; 
 			            }
-			            new dataManager(plugin).updateData(targetUUID, -amount, "Credits", "remove");
-			            if (sender == target) {
-			            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveMessage").replace("%CREDITS%", "" + amount)));
-			            	return true;
-			            } else {
-			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveSuccessMessage")));
-			            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveMessage").replace("%CREDITS%", "" + amount)));
-			            	return true;
+					} else if (checkIfUUID(args[1]) == true) {
+			        	targetUUID = UUID.fromString(args[1]);
+			        	target = Bukkit.getPlayer(targetUUID);
+			        	credits = Integer.parseInt(new dataManager(plugin).getData(targetUUID, "Credits"));
+			            if (amount > credits) {
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
+			            	return true; 
 			            }
-			        } else {
-						Player player = (Player)sender;
-						UUID uuid2 = Bukkit.getServer().getOfflinePlayer(args[1]).getUniqueId();
-						if (getFileExists(uuid2)) {
-							new dataManager(plugin).updateData(uuid2, -amount, "Credits", "remove");
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, -amount, "Credits", "remove");
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveSuccessMessage")));
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        } else if (checkIfUUID(args[1]) == false && Bukkit.getPlayer(args[1]) == null) {
+						offTarget = (OfflinePlayer)Bukkit.getServer().getOfflinePlayer(args[1]);
+						targetUUID = offTarget.getUniqueId();
+						credits = Integer.parseInt(new dataManager(plugin).getData(targetUUID, "Credits"));
+			            if (amount > credits) {
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
+			            	return true; 
+			            }
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, -amount, "Credits", "remove");
 			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveSuccessMessage")));
 							return true;
 						} else {
@@ -160,7 +230,188 @@ public class Commands implements CommandExecutor {
 							return true;
 						}
 			        }
-				}			
+		            if (amount > credits) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Remove")));
+		            	return true; 
+		            }
+		            new dataManager(plugin).updateData(targetUUID, -amount, "Credits", "remove");
+		            if (sender == target) {
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveMessage").replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            } else {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveSuccessMessage")));
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditRemoveMessage").replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            }
+		        } else {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+					return true;
+				}	
+			} else if (args[0].equalsIgnoreCase("Set")) {
+				if (sender.hasPermission("morphredeem.setcredits")) {
+					if (args.length != 3) {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Set")));
+						return true;
+					}
+		        	try {
+		        		Integer.parseInt(args[2]);
+		            }
+		            catch (NumberFormatException e) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Set")));
+		            	return true;
+		            }
+		        	int amount = Integer.parseInt(args[2]);
+		            if (amount <= 0) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Set")));
+		            	return true;
+		            }
+					Player target = null;
+					OfflinePlayer offTarget = null;
+					UUID targetUUID = null;
+					if (Bukkit.getPlayer(args[1]) != null) {
+			        	target = Bukkit.getPlayer(args[1]);
+			        	targetUUID = target.getUniqueId();
+					} else if (checkIfUUID(args[1]) == true) {
+			        	targetUUID = UUID.fromString(args[1]);
+			        	target = Bukkit.getPlayer(targetUUID);
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, amount, "Credits", "set");
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSetSuccessMessage")));
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        } else if (checkIfUUID(args[1]) == false && Bukkit.getPlayer(args[1]) == null) {
+						offTarget = (OfflinePlayer)Bukkit.getServer().getOfflinePlayer(args[1]);
+						targetUUID = offTarget.getUniqueId();
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, amount, "Credits", "set");
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSetSuccessMessage")));
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        }
+					new dataManager(plugin).updateData(targetUUID, amount, "Credits", "set");
+		            if (sender == target) {
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSetMessage").replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            } else {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSetSuccessMessage")));
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSetMessage").replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            }
+				} else {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+					return true;
+				}
+			} else if (args[0].equalsIgnoreCase("Send")) {
+				if (sender.hasPermission("morphredeem.sendcredits")) {
+					if (args.length != 3) {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Send")));
+						return true;
+					}
+		        	try {
+		        		Integer.parseInt(args[2]);
+		            }
+		            catch (NumberFormatException e) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Send")));
+		            	return true;
+		            }
+		        	Player commandSender = (Player) sender;
+		        	int amount = Integer.parseInt(args[2]);
+		            if (amount <= 0) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Send")));
+		            	return true;
+		            }
+		            int senderCreds = Integer.parseInt(new dataManager(plugin).getData(commandSender.getUniqueId(), "Credits"));
+		            if (amount > senderCreds) {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidCredits")));
+		            	return true; 
+		            }
+					Player target = null;
+					OfflinePlayer offTarget = null;
+					UUID targetUUID = null;
+					if (Bukkit.getPlayer(args[1]) != null) {
+			        	target = Bukkit.getPlayer(args[1]);
+			        	targetUUID = target.getUniqueId();
+			        } else if (Bukkit.getPlayer(args[1]) == null) {
+						offTarget = (OfflinePlayer)Bukkit.getServer().getOfflinePlayer(args[1]);
+						targetUUID = offTarget.getUniqueId();
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, +amount, "Credits", "add");
+							new dataManager(plugin).updateData(commandSender.getUniqueId(), -amount, "Credits", "remove");
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSendSuccessMessage").replace("%TARGET%", offTarget.getName()).replace("%CREDITS%", "" + amount)));
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        }
+					new dataManager(plugin).updateData(targetUUID, +amount, "Credits", "add");
+					new dataManager(plugin).updateData(commandSender.getUniqueId(), -amount, "Credits", "remove");
+		            if (sender == target) {
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSendMessage").replace("%SENDER%", sender.getName()).replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            } else {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSendSuccessMessage").replace("%TARGET%", target.getName()).replace("%CREDITS%", "" + amount)));
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditSendMessage").replace("%SENDER%", sender.getName()).replace("%CREDITS%", "" + amount)));
+		            	return true;
+		            }
+				} else {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+					return true;
+				}
+			} else if (args[0].equalsIgnoreCase("Reset")) {
+				if (sender.hasPermission("morphredeem.resetcredits")) {
+					if (args.length != 2) {
+						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("CorrectUsage.Reset")));
+						return true;
+					}
+					Player target = null;
+					OfflinePlayer offTarget = null;
+					UUID targetUUID = null;
+					if (Bukkit.getPlayer(args[1]) != null) {
+			        	target = Bukkit.getPlayer(args[1]);
+			        	targetUUID = target.getUniqueId();
+					} else if (checkIfUUID(args[1]) == true) {
+			        	targetUUID = UUID.fromString(args[1]);
+			        	target = Bukkit.getPlayer(targetUUID);
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, 0, "Credits", "set");
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditResetSuccessMessage")));
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        } else if (checkIfUUID(args[1]) == false && Bukkit.getPlayer(args[1]) == null) {
+						offTarget = (OfflinePlayer)Bukkit.getServer().getOfflinePlayer(args[1]);
+						targetUUID = offTarget.getUniqueId();
+						if (getFileExists(targetUUID)) {
+							new dataManager(plugin).updateData(targetUUID, 0, "Credits", "set");
+			            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditResetSuccessMessage")));
+							return true;
+						} else {
+							sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidPlayer")));
+							return true;
+						}
+			        }
+					new dataManager(plugin).updateData(targetUUID, 0, "Credits", "set");
+		            if (sender == target) {
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditResetMessage")));
+		            	return true;
+		            } else {
+		            	sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditResetSuccessMessage")));
+		            	target.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("Prefix") + this.plugin.getMessage("CreditResetMessage")));
+		            	return true;
+		            }
+				} else {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("NoPermsMessage")));
+					return true;
+				}
 			} else if (args[0].equalsIgnoreCase("reload")) {
 				if (sender.hasPermission("morphredeem.admin") || sender.hasPermission("morphredeem.reload")) {
 					Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("MorphRedeem");
@@ -180,6 +431,13 @@ public class Commands implements CommandExecutor {
 					Player player = (Player)sender;
 					UUID uuid = player.getUniqueId();
 					String skill = args[0];
+			        try {
+			        	Integer.parseInt(args[1]);
+			        }
+			        catch (NumberFormatException e1) {
+			        	player.sendMessage(ChatColor.translateAlternateColorCodes('&', this.plugin.getMessage("ErrorPrefix") + this.plugin.getMessage("InvalidNumber")));
+			        	return true;
+			        }
 					int amount2 = Integer.parseInt(args[1]);
 					int credits = Integer.parseInt(new dataManager(plugin).getData(uuid, "Credits"));
 					if (new McMMOMethods().doesSkillExist(player, skill) == false) {
@@ -242,4 +500,15 @@ public class Commands implements CommandExecutor {
 	    }
 	    return true;
 	  }
+	
+	public boolean checkIfUUID(String s) {
+		try {
+			UUID uuid = UUID.fromString(s);
+			return true;
+		}
+		catch(IllegalArgumentException e) {
+			return false;
+		}
+		
+	}
 }

--- a/src/net/naturva/morphie/mr/MorphRedeem.java
+++ b/src/net/naturva/morphie/mr/MorphRedeem.java
@@ -30,7 +30,7 @@ public class MorphRedeem extends JavaPlugin implements Listener {
 	public static Logger log = Logger.getLogger("Minecraft");
 	public Messages messagescfg;
 	public HashMap<Player, String> addCredits = new HashMap<Player, String>();
-	public String Version = "1.1.1";
+	public String Version = "1.2.0";
 	
 	private PlayerFileEvent pe;
 	private RedeemMenuEvent me;

--- a/src/net/naturva/morphie/mr/files/Messages.java
+++ b/src/net/naturva/morphie/mr/files/Messages.java
@@ -30,25 +30,38 @@ public class Messages implements Listener {
 	        
 	    		this.messagesCFG = YamlConfiguration.loadConfiguration(this.messagesFile);
 	    		
-	    		this.messagesCFG.addDefault("Commands.Header", "&8&m]---------+&r&8[ &9&lMorphRedeem &8]&8&m+---------[");
-	    		this.messagesCFG.addDefault("Commands.Footer", "&8&m]---------------+&r &8[&9&l!&8] &8&m+---------------[");
+	    		this.messagesCFG.addDefault("Commands.Header", "&7----------- &9&lMorphRedeem Commands &7----------");
+	    		this.messagesCFG.addDefault("Commands.Footer", "&7--------------------- &8[&9&l!&8] &7---------------------");
 	    		this.messagesCFG.addDefault("Commands.Help", "&b/mr help &8- &7Shows this text menu.");
 	    		this.messagesCFG.addDefault("Commands.MR", "&b/mr &8- &7Opens the redeem menu.");
 	    		this.messagesCFG.addDefault("Commands.MRSkill", "&b/mr <skill> <num> &8- &7Redeem credits into a specified skill.");
 	    		this.messagesCFG.addDefault("Commands.Credits", "&b/mr credits &8- &7Shows your credit count.");
+	    		this.messagesCFG.addDefault("Commands.CreditsOthers", "&b/mr credits <player> &8- &7See a players credit count.");
+	    		this.messagesCFG.addDefault("Commands.Send", "&b/mr send <player> <num> &8- &7Send a player credits.");
 	    		this.messagesCFG.addDefault("Commands.Add", "&9[Admin] &b/mr add <player> <num> &8- &7Add credits to a players credit balance.");
 	    		this.messagesCFG.addDefault("Commands.Remove", "&9[Admin] &b/mr remove <player> <num>&8- &7Remove credits to a players credit balance.");
 	    		this.messagesCFG.addDefault("Commands.Reload", "&9[Admin] &b/mr reload &8- &7Reloads the plugins files.");
+	    		this.messagesCFG.addDefault("Commands.Set", "&9[Admin] &b/mr set <player> <num> &8- &7Set a players credit balance.");
+	    		this.messagesCFG.addDefault("Commands.Reset", "&9[Admin] &b/mr reset <player> &8- &7Reset a players credit balance.");
 	    		this.messagesCFG.addDefault("CorrectUsage.Add", "&bCorrect Ussage&8: &7/mr add <player> <number>");
 	    		this.messagesCFG.addDefault("CorrectUsage.Remove", "&bCorrect Ussage&8: &7/mr remove <player> <number>");
+	    		this.messagesCFG.addDefault("CorrectUsage.Reset", "&bCorrect Ussage&8: &7/mr reset <player>");
+	    		this.messagesCFG.addDefault("CorrectUsage.Set", "&bCorrect Ussage&8: &7/mr set <player> <number>");
+	    		this.messagesCFG.addDefault("CorrectUsage.Send", "&bCorrect Ussage&8: &7/mr send <player> <number>");
 	    		this.messagesCFG.addDefault("CreditAddMessage", "&7You have been given &b%CREDITS% &7credits!");
-	    		this.messagesCFG.addDefault("CreditRemoveMessage", "&7&b%CREDITS% &7credits have been removed from you!");
 	    		this.messagesCFG.addDefault("CreditAddSuccessMessage", "&7Credit assignment successfull!");
-	    		this.messagesCFG.addDefault("CreditRemoveSuccessMessage", "&7Credit removal successfull!");
 	    		this.messagesCFG.addDefault("CreditAssignmentCanceled", "&7Credit assignment canceled successfully!");
-	    		this.messagesCFG.addDefault("CreditAssignmentMessage", "&7Please specify the ammount of credits you would like to add. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
+	    		this.messagesCFG.addDefault("CreditAssignmentMessage", "&7Please specify the amount of credits you would like to add. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
 	    		this.messagesCFG.addDefault("CreditAssignmentSuccess", "&7You successfully applied &b%CREDITS%&7 credits, to the &b%SKILL% &7skill!");
 	    		this.messagesCFG.addDefault("CreditInProgressMessage", "&7You're currently assigning credits to &b%SKILL%&7. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
+	    		this.messagesCFG.addDefault("CreditRemoveMessage", "&7&b%CREDITS% &7credits have been removed from you!");
+	    		this.messagesCFG.addDefault("CreditRemoveSuccessMessage", "&7Credit removal successfull!");
+	    		this.messagesCFG.addDefault("CreditResetMessage", "&7Your credits have been reset!");
+	    		this.messagesCFG.addDefault("CreditResetSuccessMessage", "&7Credits successfully reset!");
+	    		this.messagesCFG.addDefault("CreditSendMessage", "&7You have been sent &b%CREDITS% &7credits from &b%SENDER%&7.");
+	    		this.messagesCFG.addDefault("CreditSendSuccessMessage", "&7You sent &b%CREDITS% &7credits to &b%TARGET%&7.");
+	    		this.messagesCFG.addDefault("CreditSetMessage", "&7Your credits have been set to &b%CREDITS%&7.");
+	    		this.messagesCFG.addDefault("CreditSetSuccessMessage", "&7Credits successfull set!");
 	    		this.messagesCFG.addDefault("ErrorPrefix", "&8[&9&l!&8] ");
 	    		this.messagesCFG.addDefault("IgnoreFormat", "[X]");
 	    		this.messagesCFG.addDefault("InvalidArgsMessage", "&7Invalid arguments! &b/mr help &7to view all commands.");
@@ -79,6 +92,7 @@ public class Messages implements Listener {
 	    		list4.add(" ");
 	    		list4.add("&b&oClick for spigot link!");
 	    		
+	    		this.messagesCFG.addDefault("McMMOPlayerNotLoadedMessage", "&7Your &bmcMMO player file &7has not been loaded yet! Please try again in a &bfew seconds&7.");
 	    		this.messagesCFG.addDefault("Menu.Title", "&9&lMorphRedeem&8&l:");
 	    		this.messagesCFG.addDefault("Menu.Acrobatics.Name", "&9&lAcrobatics&8&l:");
 	    		this.messagesCFG.addDefault("Menu.Acrobatics.Lore", list);
@@ -114,6 +128,7 @@ public class Messages implements Listener {
 	    		this.messagesCFG.addDefault("Menu.PluginCredits.Lore", list4);
 	    		this.messagesCFG.addDefault("NoPermsMessage", "&7You don't have permission to do this!");
 	    		this.messagesCFG.addDefault("NoSkillCap", "&bNone");
+	    		this.messagesCFG.addDefault("OtherPlayerCreditMessage", "&b%PLAYER% &7currently has &b%CREDITS% &7credits.");
 	    		this.messagesCFG.addDefault("PlayerCreditsMessage", "&7You currently have &b%CREDITS% &7credits.");
 	    		this.messagesCFG.addDefault("Prefix", "&9&lMorphRedeem &8&l➙ ");
 	    		this.messagesCFG.addDefault("ReloadMessage", "&7Plugin files successfully reloaded!");

--- a/src/net/naturva/morphie/mr/files/PlayerFileMethods.java
+++ b/src/net/naturva/morphie/mr/files/PlayerFileMethods.java
@@ -54,7 +54,7 @@ public class PlayerFileMethods {
 	public void setData(UUID uuid, String string, int i) {
 	    File file = getPlayerFile(uuid);
 	    FileConfiguration fc = YamlConfiguration.loadConfiguration(file);
-	    fc.set(string, Integer.valueOf(fc.getInt(string) + i));
+	    fc.set(string, Integer.valueOf(i));
 	    try
 	    {
 	      fc.save(file);

--- a/src/net/naturva/morphie/mr/menus/RedeemMenu.java
+++ b/src/net/naturva/morphie/mr/menus/RedeemMenu.java
@@ -301,7 +301,11 @@ public class RedeemMenu implements Listener {
 	    
 	    int glassInt = this.plugin.getConfig().getInt("Settings.BackgroundGlassColor");
 	
-		Redeem.setItem(34, this.plugin.createInventoryItem(this.plugin.getConfig().getString("Settings.GUI.PluginCredits.ItemName"), 1, this.plugin.getMessage("Menu.PluginCredits.Name"), PluginCredits, false));
+	    if (this.plugin.getConfig().getBoolean("Settings.PluginCredits.Enabled") == true) {
+	    	Redeem.setItem(34, this.plugin.createInventoryItem(this.plugin.getConfig().getString("Settings.GUI.PluginCredits.ItemName"), 1, this.plugin.getMessage("Menu.PluginCredits.Name"), PluginCredits, false));	
+	    } else {
+	    	Redeem.setItem(34, this.plugin.createInventoryItem("BLACK_STAINED_GLASS_PANE", 1, " ", null, false));
+	    }
 		
 		Redeem.setItem(0, this.plugin.createInventoryGlassItem("LEGACY_STAINED_GLASS_PANE", glassInt, 1, " ", null, false));
 		Redeem.setItem(6, this.plugin.createInventoryGlassItem("LEGACY_STAINED_GLASS_PANE", glassInt, 1, " ", null, false));

--- a/src/net/naturva/morphie/mr/util/Database/MySQLConnection.java
+++ b/src/net/naturva/morphie/mr/util/Database/MySQLConnection.java
@@ -111,14 +111,18 @@ public class MySQLConnection {
 		}
 	}
 	
-	public void updateData(UUID uuid, int num, String column) {
+	public void updateData(UUID uuid, int num, String column, String type) {
 		if (getConnection() == null) {
 			this.mysqlSetup();
 		}
 		try {
 			int data = Integer.parseInt(this.getData(uuid, column));
 			PreparedStatement statement = this.connection.prepareStatement("UPDATE `" + this.tablePrefix + "creditdata` SET " + column.toLowerCase() + "=? WHERE uuid=?");
-			statement.setInt(1, data + num);
+			if (type.equalsIgnoreCase("set")) {
+				statement.setInt(1, num);	
+			} else if (type.equalsIgnoreCase("add") || type.equalsIgnoreCase("remove")) {
+				statement.setInt(1, data + num);
+			}
 			statement.setString(2, uuid.toString());
 			statement.executeUpdate();
 		} catch (SQLException e) {

--- a/src/net/naturva/morphie/mr/util/dataManager.java
+++ b/src/net/naturva/morphie/mr/util/dataManager.java
@@ -24,7 +24,7 @@ public class dataManager {
 	
 	public void updateData(UUID uuid, int data, String name, String type) {
 		if (this.plugin.getConfig().getString("StorageMethod").equals("MySQL")) {
-			new MySQLConnection(this.plugin).updateData(uuid, data, name);
+			new MySQLConnection(this.plugin).updateData(uuid, data, name, type);
 		} else if (type == "add" || type == "remove"){
 			new PlayerFileMethods(plugin).updateCredits(uuid, name, data);
 		} else if (type == "set") {


### PR DESCRIPTION
**_NOTE: You will need to regenerate your config and messages ymls. Failing to do so will make the plugin error out._**

Additions:

- /mr set <player> <num>
- /mr reset <player>
- /mr credits <player>
- /mr send <player> <num>
- Added an option to disable the credits item in the /mr menu.
- Added UUID support to certain commands. (Requested for Buycraft.)
- Added the spigot link to the config.yml
- Updated config formatting to look more appealing and eassier to use.

Fixes:

- Changed the base command to /morphredeem. (/redeem and /mr are still alias's)
- Typing a number larger than max would throw an internal error.
- Using the plugin to fast on join would throw an internal error. (mcMMO needed to load the player file first)
- Fixed a spelling error in the messages.yml.
- Using the /mr add <player> <num> command in console would throw an error.