### PR TITLE
Prevent NPE in MorphRedeem#getMessage()

### DIFF
--- a/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
+++ b/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
@@ -133,7 +132,7 @@ public class MorphRedeem extends JavaPlugin implements Listener {
 
 	public String getMessage(String string) {
 		if (string != null) return this.messagescfg.messagesCFG.getString(string);
-		return "Message does not exist in messages.yml!";
+		return "Null message";
 	}
 	
 	public List<String> getMessageList(String string) {

--- a/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
+++ b/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
@@ -131,7 +132,8 @@ public class MorphRedeem extends JavaPlugin implements Listener {
     }
 
 	public String getMessage(String string) {
-		return this.messagescfg.messagesCFG.getString(string);
+		if (string != null) return this.messagescfg.messagesCFG.getString(string);
+		return "Message does not exist in messages.yml!";
 	}
 	
 	public List<String> getMessageList(String string) {

--- a/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
+++ b/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
@@ -97,7 +97,7 @@ public class MorphRedeem extends JavaPlugin implements Listener {
 	}
 	
     public void loadConfigManager() {
-        this.messagescfg = new Messages();
+        this.messagescfg = new Messages(this);
         this.messagescfg.setup();
       }
   	

--- a/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
+++ b/src/main/java/net/naturva/morphie/mr/MorphRedeem.java
@@ -131,7 +131,8 @@ public class MorphRedeem extends JavaPlugin implements Listener {
     }
 
 	public String getMessage(String string) {
-		if (string != null) return this.messagescfg.messagesCFG.getString(string);
+		String gotString = this.messagescfg.messagesCFG.getString(string);
+		if (gotString != null) return gotString;
 		return "Null message";
 	}
 	

--- a/src/main/java/net/naturva/morphie/mr/files/Messages.java
+++ b/src/main/java/net/naturva/morphie/mr/files/Messages.java
@@ -15,9 +15,13 @@ import net.naturva.morphie.mr.MorphRedeem;
 
 
 public class Messages implements Listener {
-	private MorphRedeem plugin = (MorphRedeem)MorphRedeem.getPlugin(MorphRedeem.class);
+	private MorphRedeem plugin;
 	public FileConfiguration messagesCFG;
 	public File messagesFile;
+
+	public Messages(MorphRedeem plugin) {
+		this.plugin = plugin;
+	}
 	  
 	public void setup() {
 		if (!this.plugin.getDataFolder().exists()) {

--- a/src/main/java/net/naturva/morphie/mr/files/Messages.java
+++ b/src/main/java/net/naturva/morphie/mr/files/Messages.java
@@ -29,113 +29,9 @@ public class Messages implements Listener {
 	    		this.messagesFile.createNewFile();
 	        
 	    		this.messagesCFG = YamlConfiguration.loadConfiguration(this.messagesFile);
-	    		
-	    		this.messagesCFG.addDefault("Commands.Header", "&7----------- &9&lMorphRedeem Commands &7----------");
-	    		this.messagesCFG.addDefault("Commands.Footer", "&7--------------------- &8[&9&l!&8] &7---------------------");
-	    		this.messagesCFG.addDefault("Commands.Help", "&b/mr help &8- &7Shows this text menu.");
-	    		this.messagesCFG.addDefault("Commands.MR", "&b/mr &8- &7Opens the redeem menu.");
-	    		this.messagesCFG.addDefault("Commands.MRSkill", "&b/mr <skill> <num> &8- &7Redeem credits into a specified skill.");
-	    		this.messagesCFG.addDefault("Commands.Credits", "&b/mr credits &8- &7Shows your credit count.");
-	    		this.messagesCFG.addDefault("Commands.CreditsOthers", "&b/mr credits <player> &8- &7See a players credit count.");
-	    		this.messagesCFG.addDefault("Commands.Send", "&b/mr send <player> <num> &8- &7Send a player credits.");
-	    		this.messagesCFG.addDefault("Commands.Add", "&9[Admin] &b/mr add <player> <num> &8- &7Add credits to a players credit balance.");
-	    		this.messagesCFG.addDefault("Commands.Remove", "&9[Admin] &b/mr remove <player> <num>&8- &7Remove credits to a players credit balance.");
-	    		this.messagesCFG.addDefault("Commands.Reload", "&9[Admin] &b/mr reload &8- &7Reloads the plugins files.");
-	    		this.messagesCFG.addDefault("Commands.Set", "&9[Admin] &b/mr set <player> <num> &8- &7Set a players credit balance.");
-	    		this.messagesCFG.addDefault("Commands.Reset", "&9[Admin] &b/mr reset <player> &8- &7Reset a players credit balance.");
-	    		this.messagesCFG.addDefault("CorrectUsage.Add", "&bCorrect Ussage&8: &7/mr add <player> <number>");
-	    		this.messagesCFG.addDefault("CorrectUsage.Remove", "&bCorrect Ussage&8: &7/mr remove <player> <number>");
-	    		this.messagesCFG.addDefault("CorrectUsage.Reset", "&bCorrect Ussage&8: &7/mr reset <player>");
-	    		this.messagesCFG.addDefault("CorrectUsage.Set", "&bCorrect Ussage&8: &7/mr set <player> <number>");
-	    		this.messagesCFG.addDefault("CorrectUsage.Send", "&bCorrect Ussage&8: &7/mr send <player> <number>");
-	    		this.messagesCFG.addDefault("CreditAddMessage", "&7You have been given &b%CREDITS% &7credits!");
-	    		this.messagesCFG.addDefault("CreditAddSuccessMessage", "&7Credit assignment successfull!");
-	    		this.messagesCFG.addDefault("CreditAssignmentCanceled", "&7Credit assignment canceled successfully!");
-	    		this.messagesCFG.addDefault("CreditAssignmentMessage", "&7Please specify the amount of credits you would like to add. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
-	    		this.messagesCFG.addDefault("CreditAssignmentSuccess", "&7You successfully applied &b%CREDITS%&7 credits, to the &b%SKILL% &7skill!");
-	    		this.messagesCFG.addDefault("CreditInProgressMessage", "&7You're currently assigning credits to &b%SKILL%&7. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
-	    		this.messagesCFG.addDefault("CreditRemoveMessage", "&7&b%CREDITS% &7credits have been removed from you!");
-	    		this.messagesCFG.addDefault("CreditRemoveSuccessMessage", "&7Credit removal successfull!");
-	    		this.messagesCFG.addDefault("CreditResetMessage", "&7Your credits have been reset!");
-	    		this.messagesCFG.addDefault("CreditResetSuccessMessage", "&7Credits successfully reset!");
-	    		this.messagesCFG.addDefault("CreditSendMessage", "&7You have been sent &b%CREDITS% &7credits from &b%SENDER%&7.");
-	    		this.messagesCFG.addDefault("CreditSendSuccessMessage", "&7You sent &b%CREDITS% &7credits to &b%TARGET%&7.");
-	    		this.messagesCFG.addDefault("CreditSetMessage", "&7Your credits have been set to &b%CREDITS%&7.");
-	    		this.messagesCFG.addDefault("CreditSetSuccessMessage", "&7Credits successfull set!");
-	    		this.messagesCFG.addDefault("ErrorPrefix", "&8[&9&l!&8] ");
-	    		this.messagesCFG.addDefault("IgnoreFormat", "[X]");
-	    		this.messagesCFG.addDefault("InvalidArgsMessage", "&7Invalid arguments! &b/mr help &7to view all commands.");
-	    		this.messagesCFG.addDefault("InvalidCredits", "&7You do not have the valid credits for this! Canceling credit assignment.");
-	    		this.messagesCFG.addDefault("InvalidNumber", "&7The message entered was not recognized as a number! Canceling credit assignment.");
-	    		this.messagesCFG.addDefault("InvalidNumberNegative", "&7The number you entered was not positive! Canceling credit assignment.");
-	    		this.messagesCFG.addDefault("InvalidPlayer", "&7Cannot find that player!");
-	    		this.messagesCFG.addDefault("InvalidSkill", "&7The argument entered was not recognized as a skill!");
-	   
-	    		List<String> list = new ArrayList<String>();
-	    		list.add(" ");
-	    		list.add("&7Click to assign credits!");
-	    		list.add(" ");
-	    		list.add("&b➙ &7Level Cap&8: &7%LEVELCAP%");
-	    		list.add("&b➙ &7Skill Level&8: &7%SKILLLEVEL%");
-	    		
-	    		List<String> list2 = new ArrayList<String>();
-	    		list2.add("&b➙ &7%MCMMOCREDITS%");
-	    		
-	    		List<String> list3 = new ArrayList<String>();
-	    		list3.add("&b➙ &7%CREDITSSPENT%");
-	    		
-	    		List<String> list4 = new ArrayList<String>();
-	    		list4.add("&9&lVersion&8: &7" + this.plugin.Version);
-	    		list4.add(" ");
-	    		list4.add("&bCode Contributors&8:");
-	    		list4.add("&8- &7Morphie");
-	    		list4.add(" ");
-	    		list4.add("&b&oClick for spigot link!");
-	    		
-	    		this.messagesCFG.addDefault("McMMOPlayerNotLoadedMessage", "&7Your &bmcMMO player file &7has not been loaded yet! Please try again in a &bfew seconds&7.");
-	    		this.messagesCFG.addDefault("Menu.Title", "&9&lMorphRedeem&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Acrobatics.Name", "&9&lAcrobatics&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Acrobatics.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Alchemy.Name", "&9&lAlchemy&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Alchemy.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Archery.Name", "&9&lArchery&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Archery.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Axes.Name", "&9&lAxes&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Axes.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Excavation.Name", "&9&lExcavation&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Excavation.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Fishing.Name", "&9&lFishing&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Fishing.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Herbalism.Name", "&9&lHerbalism&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Herbalism.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Mining.Name", "&9&lMining&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Mining.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Repair.Name", "&9&lRepair&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Repair.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Swords.Name", "&9&lSwords&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Swords.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Taming.Name", "&9&lTaming&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Taming.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Unarmed.Name", "&9&lUnarmed&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Unarmed.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.Woodcutting.Name", "&9&lWoodcutting&8&l:");
-	    		this.messagesCFG.addDefault("Menu.Woodcutting.Lore", list);
-	    		this.messagesCFG.addDefault("Menu.mcMMOCredits.Name", "&9&lmcMMO Credits&8&l:");
-	    		this.messagesCFG.addDefault("Menu.mcMMOCredits.Lore", list2);
-	    		this.messagesCFG.addDefault("Menu.CreditsSpent.Name", "&9&lCredits Spent&8&l:");
-	    		this.messagesCFG.addDefault("Menu.CreditsSpent.Lore", list3);
-	    		this.messagesCFG.addDefault("Menu.PluginCredits.Name", "&9&lPlugin Credits&8&l:");
-	    		this.messagesCFG.addDefault("Menu.PluginCredits.Lore", list4);
-	    		this.messagesCFG.addDefault("NoPermsMessage", "&7You don't have permission to do this!");
-	    		this.messagesCFG.addDefault("NoSkillCap", "&bNone");
-	    		this.messagesCFG.addDefault("OtherPlayerCreditMessage", "&b%PLAYER% &7currently has &b%CREDITS% &7credits.");
-	    		this.messagesCFG.addDefault("PlayerCreditsMessage", "&7You currently have &b%CREDITS% &7credits.");
-	    		this.messagesCFG.addDefault("Prefix", "&9&lMorphRedeem &8&l➙ ");
-	    		this.messagesCFG.addDefault("ReloadMessage", "&7Plugin files successfully reloaded!");
-	    		this.messagesCFG.addDefault("SkillCapReached", "&7You tried to get to level &b%LEVEL% &7in &b%SKILL%&7, but the skill cap is &b%CAP%&7.");
-	    		this.messagesCFG.addDefault("SkillDisabledMessage", "&7This skill has been disabled by administration!");
-	    		this.messagesCFG.addDefault("SpigotLink", "&7https://www.spigotmc.org/resources/morphredeem-mcmmo-credits-1-14.67435/");
-	        
+
+	    		this.addDefaults(this.messagesCFG);
+
 	    		this.messagesCFG.options().copyDefaults(true);
 	    		saveMessages();
 	    	} catch (IOException e) {
@@ -143,6 +39,8 @@ public class Messages implements Listener {
 	    	}
 	    }
 	    this.messagesCFG = YamlConfiguration.loadConfiguration(this.messagesFile);
+
+	    this.addDefaults(this.messagesCFG);
 	}
 	  
     public void saveMessages() {
@@ -155,6 +53,114 @@ public class Messages implements Listener {
 	  
     public void reloadMessages() {
     	this.messagesCFG = YamlConfiguration.loadConfiguration(this.messagesFile);
+    	this.addDefaults(this.messagesCFG);
     }
     
+    private void addDefaults(FileConfiguration cfg) {
+		cfg.addDefault("Commands.Header", "&7----------- &9&lMorphRedeem Commands &7----------");
+		cfg.addDefault("Commands.Footer", "&7--------------------- &8[&9&l!&8] &7---------------------");
+		cfg.addDefault("Commands.Help", "&b/mr help &8- &7Shows this text menu.");
+		cfg.addDefault("Commands.MR", "&b/mr &8- &7Opens the redeem menu.");
+		cfg.addDefault("Commands.MRSkill", "&b/mr <skill> <num> &8- &7Redeem credits into a specified skill.");
+		cfg.addDefault("Commands.Credits", "&b/mr credits &8- &7Shows your credit count.");
+		cfg.addDefault("Commands.CreditsOthers", "&b/mr credits <player> &8- &7See a players credit count.");
+		cfg.addDefault("Commands.Send", "&b/mr send <player> <num> &8- &7Send a player credits.");
+		cfg.addDefault("Commands.Add", "&9[Admin] &b/mr add <player> <num> &8- &7Add credits to a players credit balance.");
+		cfg.addDefault("Commands.Remove", "&9[Admin] &b/mr remove <player> <num>&8- &7Remove credits to a players credit balance.");
+		cfg.addDefault("Commands.Reload", "&9[Admin] &b/mr reload &8- &7Reloads the plugins files.");
+		cfg.addDefault("Commands.Set", "&9[Admin] &b/mr set <player> <num> &8- &7Set a players credit balance.");
+		cfg.addDefault("Commands.Reset", "&9[Admin] &b/mr reset <player> &8- &7Reset a players credit balance.");
+		cfg.addDefault("CorrectUsage.Add", "&bCorrect Ussage&8: &7/mr add <player> <number>");
+		cfg.addDefault("CorrectUsage.Remove", "&bCorrect Ussage&8: &7/mr remove <player> <number>");
+		cfg.addDefault("CorrectUsage.Reset", "&bCorrect Ussage&8: &7/mr reset <player>");
+		cfg.addDefault("CorrectUsage.Set", "&bCorrect Ussage&8: &7/mr set <player> <number>");
+		cfg.addDefault("CorrectUsage.Send", "&bCorrect Ussage&8: &7/mr send <player> <number>");
+		cfg.addDefault("CreditAddMessage", "&7You have been given &b%CREDITS% &7credits!");
+		cfg.addDefault("CreditAddSuccessMessage", "&7Credit assignment successfull!");
+		cfg.addDefault("CreditAssignmentCanceled", "&7Credit assignment canceled successfully!");
+		cfg.addDefault("CreditAssignmentMessage", "&7Please specify the amount of credits you would like to add. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
+		cfg.addDefault("CreditAssignmentSuccess", "&7You successfully applied &b%CREDITS%&7 credits, to the &b%SKILL% &7skill!");
+		cfg.addDefault("CreditInProgressMessage", "&7You're currently assigning credits to &b%SKILL%&7. Write 0 in chat to cancel! &8(&bCredits&8: &7%CREDITS%&8)");
+		cfg.addDefault("CreditRemoveMessage", "&7&b%CREDITS% &7credits have been removed from you!");
+		cfg.addDefault("CreditRemoveSuccessMessage", "&7Credit removal successfull!");
+		cfg.addDefault("CreditResetMessage", "&7Your credits have been reset!");
+		cfg.addDefault("CreditResetSuccessMessage", "&7Credits successfully reset!");
+		cfg.addDefault("CreditSendMessage", "&7You have been sent &b%CREDITS% &7credits from &b%SENDER%&7.");
+		cfg.addDefault("CreditSendSuccessMessage", "&7You sent &b%CREDITS% &7credits to &b%TARGET%&7.");
+		cfg.addDefault("CreditSetMessage", "&7Your credits have been set to &b%CREDITS%&7.");
+		cfg.addDefault("CreditSetSuccessMessage", "&7Credits successfull set!");
+		cfg.addDefault("ErrorPrefix", "&8[&9&l!&8] ");
+		cfg.addDefault("IgnoreFormat", "[X]");
+		cfg.addDefault("InvalidArgsMessage", "&7Invalid arguments! &b/mr help &7to view all commands.");
+		cfg.addDefault("InvalidCredits", "&7You do not have the valid credits for this! Canceling credit assignment.");
+		cfg.addDefault("InvalidNumber", "&7The message entered was not recognized as a number! Canceling credit assignment.");
+		cfg.addDefault("InvalidNumberNegative", "&7The number you entered was not positive! Canceling credit assignment.");
+		cfg.addDefault("InvalidPlayer", "&7Cannot find that player!");
+		cfg.addDefault("InvalidSkill", "&7The argument entered was not recognized as a skill!");
+
+		List<String> list = new ArrayList<String>();
+		list.add(" ");
+		list.add("&7Click to assign credits!");
+		list.add(" ");
+		list.add("&b➙ &7Level Cap&8: &7%LEVELCAP%");
+		list.add("&b➙ &7Skill Level&8: &7%SKILLLEVEL%");
+
+		List<String> list2 = new ArrayList<String>();
+		list2.add("&b➙ &7%MCMMOCREDITS%");
+
+		List<String> list3 = new ArrayList<String>();
+		list3.add("&b➙ &7%CREDITSSPENT%");
+
+		List<String> list4 = new ArrayList<String>();
+		list4.add("&9&lVersion&8: &7" + this.plugin.Version);
+		list4.add(" ");
+		list4.add("&bCode Contributors&8:");
+		list4.add("&8- &7Morphie");
+		list4.add(" ");
+		list4.add("&b&oClick for spigot link!");
+
+		cfg.addDefault("McMMOPlayerNotLoadedMessage", "&7Your &bmcMMO player file &7has not been loaded yet! Please try again in a &bfew seconds&7.");
+		cfg.addDefault("Menu.Title", "&9&lMorphRedeem&8&l:");
+		cfg.addDefault("Menu.Acrobatics.Name", "&9&lAcrobatics&8&l:");
+		cfg.addDefault("Menu.Acrobatics.Lore", list);
+		cfg.addDefault("Menu.Alchemy.Name", "&9&lAlchemy&8&l:");
+		cfg.addDefault("Menu.Alchemy.Lore", list);
+		cfg.addDefault("Menu.Archery.Name", "&9&lArchery&8&l:");
+		cfg.addDefault("Menu.Archery.Lore", list);
+		cfg.addDefault("Menu.Axes.Name", "&9&lAxes&8&l:");
+		cfg.addDefault("Menu.Axes.Lore", list);
+		cfg.addDefault("Menu.Excavation.Name", "&9&lExcavation&8&l:");
+		cfg.addDefault("Menu.Excavation.Lore", list);
+		cfg.addDefault("Menu.Fishing.Name", "&9&lFishing&8&l:");
+		cfg.addDefault("Menu.Fishing.Lore", list);
+		cfg.addDefault("Menu.Herbalism.Name", "&9&lHerbalism&8&l:");
+		cfg.addDefault("Menu.Herbalism.Lore", list);
+		cfg.addDefault("Menu.Mining.Name", "&9&lMining&8&l:");
+		cfg.addDefault("Menu.Mining.Lore", list);
+		cfg.addDefault("Menu.Repair.Name", "&9&lRepair&8&l:");
+		cfg.addDefault("Menu.Repair.Lore", list);
+		cfg.addDefault("Menu.Swords.Name", "&9&lSwords&8&l:");
+		cfg.addDefault("Menu.Swords.Lore", list);
+		cfg.addDefault("Menu.Taming.Name", "&9&lTaming&8&l:");
+		cfg.addDefault("Menu.Taming.Lore", list);
+		cfg.addDefault("Menu.Unarmed.Name", "&9&lUnarmed&8&l:");
+		cfg.addDefault("Menu.Unarmed.Lore", list);
+		cfg.addDefault("Menu.Woodcutting.Name", "&9&lWoodcutting&8&l:");
+		cfg.addDefault("Menu.Woodcutting.Lore", list);
+		cfg.addDefault("Menu.mcMMOCredits.Name", "&9&lmcMMO Credits&8&l:");
+		cfg.addDefault("Menu.mcMMOCredits.Lore", list2);
+		cfg.addDefault("Menu.CreditsSpent.Name", "&9&lCredits Spent&8&l:");
+		cfg.addDefault("Menu.CreditsSpent.Lore", list3);
+		cfg.addDefault("Menu.PluginCredits.Name", "&9&lPlugin Credits&8&l:");
+		cfg.addDefault("Menu.PluginCredits.Lore", list4);
+		cfg.addDefault("NoPermsMessage", "&7You don't have permission to do this!");
+		cfg.addDefault("NoSkillCap", "&bNone");
+		cfg.addDefault("OtherPlayerCreditMessage", "&b%PLAYER% &7currently has &b%CREDITS% &7credits.");
+		cfg.addDefault("PlayerCreditsMessage", "&7You currently have &b%CREDITS% &7credits.");
+		cfg.addDefault("Prefix", "&9&lMorphRedeem &8&l➙ ");
+		cfg.addDefault("ReloadMessage", "&7Plugin files successfully reloaded!");
+		cfg.addDefault("SkillCapReached", "&7You tried to get to level &b%LEVEL% &7in &b%SKILL%&7, but the skill cap is &b%CAP%&7.");
+		cfg.addDefault("SkillDisabledMessage", "&7This skill has been disabled by administration!");
+		cfg.addDefault("SpigotLink", "&7https://www.spigotmc.org/resources/morphredeem-mcmmo-credits-1-14.67435/");
+	}
 }


### PR DESCRIPTION
This should fix an internal error issue caused by message keys not existing in messages.yml, and would provide the plugin's user more useful information than just "An internal error". I set the return message if null to "Null message", but this could be set to "Message non-existent in messages.yml" for example, so that a server administrator could fix their config appropriately.

I haven't compiled this to test, but I'd imagine it works.